### PR TITLE
🔒 [security fix] Fix search query injection in Google Drive service

### DIFF
--- a/pygog/services/drive.py
+++ b/pygog/services/drive.py
@@ -74,7 +74,7 @@ class DriveService(BaseService):
         """
         query_parts = ["trashed = false"]
         if parent_id:
-            safe_parent_id = parent_id.replace("'", "\\'")
+            safe_parent_id = parent_id.replace("\\", "\\\\").replace("'", "\\'")
             query_parts.append(f"'{safe_parent_id}' in parents")
 
         return self._files().list(
@@ -101,7 +101,7 @@ class DriveService(BaseService):
         Returns:
             Dict with 'files' list and optional 'nextPageToken'
         """
-        safe_query = query.replace("'", "\\'")
+        safe_query = query.replace("\\", "\\\\").replace("'", "\\'")
         q = f"(name contains '{safe_query}' or fullText contains '{safe_query}') and trashed = false"
 
         return self._files().list(

--- a/pygog/services/drive.py
+++ b/pygog/services/drive.py
@@ -74,7 +74,8 @@ class DriveService(BaseService):
         """
         query_parts = ["trashed = false"]
         if parent_id:
-            query_parts.append(f"'{parent_id}' in parents")
+            safe_parent_id = parent_id.replace("'", "\\'")
+            query_parts.append(f"'{safe_parent_id}' in parents")
 
         return self._files().list(
             q=" and ".join(query_parts),
@@ -100,7 +101,8 @@ class DriveService(BaseService):
         Returns:
             Dict with 'files' list and optional 'nextPageToken'
         """
-        q = f"(name contains '{query}' or fullText contains '{query}') and trashed = false"
+        safe_query = query.replace("'", "\\'")
+        q = f"(name contains '{safe_query}' or fullText contains '{safe_query}') and trashed = false"
 
         return self._files().list(
             q=q,

--- a/tests/test_drive_security.py
+++ b/tests/test_drive_security.py
@@ -84,5 +84,63 @@ class TestDriveSecurity(unittest.TestCase):
         self.assertIn(f"'{expected_parent}'", q)
         self.assertNotIn(f"'{malicious_parent}'", q)
 
+    @patch("pygog.services.base.get_config")
+    def test_backslash_escaping(self, mock_get_config):
+        # Mock config
+        mock_config = MagicMock()
+        mock_config.resolve_account.return_value = "test@example.com"
+        mock_config.get_client_for_account.return_value = "test-client"
+        mock_get_config.return_value = mock_config
+
+        # Mock Drive API service
+        service = DriveService(account="test@example.com")
+        mock_drive_service = MagicMock()
+        service._service = mock_drive_service
+
+        mock_files = mock_drive_service.files.return_value
+
+        # Input: foo\
+        query = "foo\\"
+        service.search_files(query=query)
+
+        args, kwargs = mock_files.list.call_args
+        q = kwargs.get('q')
+
+        print(f"Generated query with backslash: {q}")
+
+        # foo\ -> foo\\
+        # In Python string literal for expectation: "foo\\\\"
+        expected_query = "foo\\\\"
+        self.assertIn(f"'{expected_query}'", q)
+
+    @patch("pygog.services.base.get_config")
+    def test_backslash_quote_escaping(self, mock_get_config):
+        # Mock config
+        mock_config = MagicMock()
+        mock_config.resolve_account.return_value = "test@example.com"
+        mock_config.get_client_for_account.return_value = "test-client"
+        mock_get_config.return_value = mock_config
+
+        # Mock Drive API service
+        service = DriveService(account="test@example.com")
+        mock_drive_service = MagicMock()
+        service._service = mock_drive_service
+
+        mock_files = mock_drive_service.files.return_value
+
+        # Input: foo\'
+        query = "foo\\'"
+        service.search_files(query=query)
+
+        args, kwargs = mock_files.list.call_args
+        q = kwargs.get('q')
+
+        print(f"Generated query with backslash and quote: {q}")
+
+        # foo\' -> foo\\\'
+        # In Python string literal for expectation: "foo\\\\\\'"
+        expected_query = "foo\\\\\\'"
+        self.assertIn(f"'{expected_query}'", q)
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_drive_security.py
+++ b/tests/test_drive_security.py
@@ -1,0 +1,88 @@
+import unittest
+from unittest.mock import MagicMock, patch
+import sys
+
+# Mock necessary modules
+sys.modules['googleapiclient'] = MagicMock()
+sys.modules['googleapiclient.discovery'] = MagicMock()
+sys.modules['googleapiclient.http'] = MagicMock()
+sys.modules['google.oauth2.credentials'] = MagicMock()
+sys.modules['google_auth_oauthlib.flow'] = MagicMock()
+sys.modules['google.auth.transport.requests'] = MagicMock()
+sys.modules['typer'] = MagicMock()
+sys.modules['rich'] = MagicMock()
+sys.modules['rich.console'] = MagicMock()
+sys.modules['rich.table'] = MagicMock()
+sys.modules['json5'] = MagicMock()
+sys.modules['keyring'] = MagicMock()
+sys.modules['keyring.errors'] = MagicMock()
+sys.modules['litellm'] = MagicMock()
+sys.modules['ddgs'] = MagicMock()
+sys.modules['python-dateutil'] = MagicMock()
+sys.modules['dateutil'] = MagicMock()
+sys.modules['dateutil.parser'] = MagicMock()
+
+from pygog.services.drive import DriveService
+
+class TestDriveSecurity(unittest.TestCase):
+    @patch("pygog.services.base.get_config")
+    def test_search_files_injection(self, mock_get_config):
+        # Mock config
+        mock_config = MagicMock()
+        mock_config.resolve_account.return_value = "test@example.com"
+        mock_config.get_client_for_account.return_value = "test-client"
+        mock_get_config.return_value = mock_config
+
+        # Mock Drive API service
+        service = DriveService(account="test@example.com")
+        mock_drive_service = MagicMock()
+        service._service = mock_drive_service
+
+        mock_files = mock_drive_service.files.return_value
+
+        # Malicious query to break out of quotes
+        malicious_query = "foo' or name contains 'bar"
+        service.search_files(query=malicious_query)
+
+        # Check the 'q' parameter passed to list()
+        args, kwargs = mock_files.list.call_args
+        q = kwargs.get('q')
+
+        print(f"Generated query: {q}")
+
+        # Verify that single quotes are escaped
+        expected_query = "foo\\' or name contains \\'bar"
+        self.assertIn(f"'{expected_query}'", q)
+        # Verify that it doesn't contain the unescaped malicious query
+        self.assertNotIn(f"'{malicious_query}'", q)
+
+    @patch("pygog.services.base.get_config")
+    def test_list_files_injection(self, mock_get_config):
+        # Mock config
+        mock_config = MagicMock()
+        mock_config.resolve_account.return_value = "test@example.com"
+        mock_config.get_client_for_account.return_value = "test-client"
+        mock_get_config.return_value = mock_config
+
+        # Mock Drive API service
+        service = DriveService(account="test@example.com")
+        mock_drive_service = MagicMock()
+        service._service = mock_drive_service
+
+        mock_files = mock_drive_service.files.return_value
+
+        # Malicious parent_id
+        malicious_parent = "foo' or 'bar' in parents"
+        service.list_files(parent_id=malicious_parent)
+
+        args, kwargs = mock_files.list.call_args
+        q = kwargs.get('q')
+
+        print(f"Generated query for list_files: {q}")
+
+        expected_parent = "foo\\' or \\'bar\\' in parents"
+        self.assertIn(f"'{expected_parent}'", q)
+        self.assertNotIn(f"'{malicious_parent}'", q)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
The vulnerability was a search query injection in the Google Drive service. User-provided search terms and parent folder IDs were interpolated into the search query string without proper escaping of single quotes.

### ⚠️ Risk: The potential impact if left unfixed
An attacker could provide a malicious query string containing single quotes to break out of the intended search parameters and manipulate the search query logic. This could potentially allow them to access files or information they shouldn't have access to, or at least bypass intended search filters (e.g., searching in trashed files or across all folders when a specific parent folder was intended).

### 🛡️ Solution: How the fix addresses the vulnerability
The fix implements single-quote escaping for the `query` parameter in `search_files()` and the `parent_id` parameter in `list_files()`. According to the Google Drive API documentation, single quotes in query strings must be escaped with a backslash (e.g., `'` becomes `\'`).

```python
safe_query = query.replace("'", "\\'")
q = f"(name contains '{safe_query}' or fullText contains '{safe_query}') and trashed = false"
```

A reproduction test was added to `tests/test_drive_security.py` that mocks the Google API client and verifies that malicious input is correctly escaped before being sent to the API.

---
*PR created automatically by Jules for task [11644403225619980441](https://jules.google.com/task/11644403225619980441) started by @DhruvGarg111*