### PR TITLE
Feature: Add --dry-run to Drive delete/move/rename

### DIFF
--- a/pygog/commands/drive.py
+++ b/pygog/commands/drive.py
@@ -229,11 +229,7 @@ def rename_cmd(
     dry_run: bool = typer.Option(False, "--dry-run", help="Preview the action without executing"),
 ):
     """Rename a file."""
-    service = get_service()
-
     if dry_run:
-        original = service.get_file(file_id)
-        original_name = original.get("name", file_id)
         if should_json():
             print_json({
                 "dryRun": True,
@@ -241,16 +237,18 @@ def rename_cmd(
                 "status": "success",
                 "action": "renamed",
                 "fileId": file_id,
+                "newName": name,
             })
             return
 
         if should_plain():
-            print(f"[DRY RUN, NO FILES AFFECTED] Renamed '{original_name}' to '{name}'")
+            print(f"[DRY RUN, NO FILES AFFECTED] Renamed file '{file_id}' to '{name}'")
             return
 
-        console.print(f"[DRY RUN, NO FILES AFFECTED] [green][OK][/green] Renamed '{original_name}' to '{name}'")
+        console.print(f"[DRY RUN, NO FILES AFFECTED] [green][OK][/green] Renamed file '{file_id}' to '{name}'")
         return
 
+    service = get_service()
     result = service.rename_file(file_id, name)
 
     if should_json():
@@ -271,11 +269,7 @@ def move_cmd(
     dry_run: bool = typer.Option(False, "--dry-run", help="Preview the action without executing"),
 ):
     """Move a file to a different folder."""
-    service = get_service()
-
     if dry_run:
-        original = service.get_file(file_id)
-        original_name = original.get("name", file_id)
         if should_json():
             print_json({
                 "dryRun": True,
@@ -283,16 +277,18 @@ def move_cmd(
                 "status": "success",
                 "action": "moved",
                 "fileId": file_id,
+                "parent": parent,
             })
             return
 
         if should_plain():
-            print(f"[DRY RUN, NO FILES AFFECTED] Moved '{original_name}' (ID: {file_id}) to folder {parent}")
+            print(f"[DRY RUN, NO FILES AFFECTED] Moved file '{file_id}' to folder {parent}")
             return
 
-        console.print(f"[DRY RUN, NO FILES AFFECTED] [green][OK][/green] Moved '{original_name}' (ID: {file_id}) to folder {parent}")
+        console.print(f"[DRY RUN, NO FILES AFFECTED] [green][OK][/green] Moved file '{file_id}' to folder {parent}")
         return
 
+    service = get_service()
     result = service.move_file(file_id, parent)
 
     if should_json():

--- a/pygog/commands/drive.py
+++ b/pygog/commands/drive.py
@@ -226,13 +226,39 @@ def copy_cmd(
 def rename_cmd(
     file_id: str = typer.Argument(..., help="File ID"),
     name: str = typer.Argument(..., help="New name"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview the action without executing"),
 ):
     """Rename a file."""
     service = get_service()
+
+    if dry_run:
+        original = service.get_file(file_id)
+        original_name = original.get("name", file_id)
+        if should_json():
+            print_json({
+                "dryRun": True,
+                "message": "DRY RUN, NO FILES AFFECTED",
+                "status": "success",
+                "action": "renamed",
+                "fileId": file_id,
+            })
+            return
+
+        if should_plain():
+            print(f"[DRY RUN, NO FILES AFFECTED] Renamed '{original_name}' to '{name}'")
+            return
+
+        console.print(f"[DRY RUN, NO FILES AFFECTED] [green][OK][/green] Renamed '{original_name}' to '{name}'")
+        return
+
     result = service.rename_file(file_id, name)
 
     if should_json():
         print_json({"file": result})
+        return
+
+    if should_plain():
+        print(f"Renamed to: {name}")
         return
 
     console.print(f"[green][OK][/green] Renamed to: [cyan]{name}[/cyan]")
@@ -242,13 +268,39 @@ def rename_cmd(
 def move_cmd(
     file_id: str = typer.Argument(..., help="File ID"),
     parent: str = typer.Option(..., "--parent", "-p", help="Destination folder ID"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview the action without executing"),
 ):
     """Move a file to a different folder."""
     service = get_service()
+
+    if dry_run:
+        original = service.get_file(file_id)
+        original_name = original.get("name", file_id)
+        if should_json():
+            print_json({
+                "dryRun": True,
+                "message": "DRY RUN, NO FILES AFFECTED",
+                "status": "success",
+                "action": "moved",
+                "fileId": file_id,
+            })
+            return
+
+        if should_plain():
+            print(f"[DRY RUN, NO FILES AFFECTED] Moved '{original_name}' (ID: {file_id}) to folder {parent}")
+            return
+
+        console.print(f"[DRY RUN, NO FILES AFFECTED] [green][OK][/green] Moved '{original_name}' (ID: {file_id}) to folder {parent}")
+        return
+
     result = service.move_file(file_id, parent)
 
     if should_json():
         print_json({"file": result})
+        return
+
+    if should_plain():
+        print(f"Moved: {result.get('name', file_id)}")
         return
 
     console.print(f"[green][OK][/green] Moved: {result.get('name', file_id)}")
@@ -258,9 +310,28 @@ def move_cmd(
 def delete_cmd(
     file_id: str = typer.Argument(..., help="File ID"),
     force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation"),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview the action without executing"),
 ):
     """Move a file to trash."""
     from pygog.cli import state
+
+    if dry_run:
+        if should_json():
+            print_json({
+                "dryRun": True,
+                "message": "DRY RUN, NO FILES AFFECTED",
+                "status": "success",
+                "action": "deleted",
+                "fileId": file_id,
+            })
+            return
+
+        if should_plain():
+            print(f"[DRY RUN, NO FILES AFFECTED] Moved to trash: {file_id}")
+            return
+
+        console.print(f"[DRY RUN, NO FILES AFFECTED] [green][OK][/green] Moved to trash: {file_id}")
+        return
 
     if not force and not state.force:
         confirm = typer.confirm(f"Move file {file_id} to trash?")
@@ -272,6 +343,10 @@ def delete_cmd(
 
     if should_json():
         print_json({"deleted": True, "fileId": file_id})
+        return
+
+    if should_plain():
+        print(f"Moved to trash: {file_id}")
         return
 
     console.print(f"[green][OK][/green] Moved to trash: {file_id}")

--- a/tests/test_drive_dry_run.py
+++ b/tests/test_drive_dry_run.py
@@ -1,0 +1,72 @@
+
+import pytest
+from unittest.mock import MagicMock, patch
+from typer.testing import CliRunner
+from pygog.commands.drive import app
+from pygog.cli import state
+
+runner = CliRunner()
+
+@pytest.fixture(autouse=True)
+def mock_state():
+    state.json_output = False
+    state.plain_output = False
+    state.force = False
+    yield
+    state.json_output = False
+    state.plain_output = False
+    state.force = False
+
+@patch("pygog.commands.drive.get_service")
+def test_rename_dry_run(mock_get_service):
+    result = runner.invoke(app, ["rename", "123", "new_name.txt", "--dry-run"])
+    assert result.exit_code == 0
+    assert "[DRY RUN, NO FILES AFFECTED]" in result.stdout
+    assert "Renamed file '123' to 'new_name.txt'" in result.stdout
+    mock_get_service.assert_not_called()
+
+@patch("pygog.commands.drive.get_service")
+def test_rename_dry_run_json(mock_get_service):
+    state.json_output = True
+    result = runner.invoke(app, ["rename", "123", "new_name.txt", "--dry-run"])
+    assert result.exit_code == 0
+    assert '"dryRun": true' in result.stdout
+    assert '"newName": "new_name.txt"' in result.stdout
+    assert '"fileId": "123"' in result.stdout
+    mock_get_service.assert_not_called()
+
+@patch("pygog.commands.drive.get_service")
+def test_move_dry_run(mock_get_service):
+    result = runner.invoke(app, ["move", "123", "--parent", "folder456", "--dry-run"])
+    assert result.exit_code == 0
+    assert "[DRY RUN, NO FILES AFFECTED]" in result.stdout
+    assert "Moved file '123' to folder folder456" in result.stdout
+    mock_get_service.assert_not_called()
+
+@patch("pygog.commands.drive.get_service")
+def test_move_dry_run_json(mock_get_service):
+    state.json_output = True
+    result = runner.invoke(app, ["move", "123", "--parent", "folder456", "--dry-run"])
+    assert result.exit_code == 0
+    assert '"dryRun": true' in result.stdout
+    assert '"parent": "folder456"' in result.stdout
+    assert '"fileId": "123"' in result.stdout
+    mock_get_service.assert_not_called()
+
+@patch("pygog.commands.drive.get_service")
+def test_delete_dry_run(mock_get_service):
+    result = runner.invoke(app, ["delete", "123", "--dry-run"])
+    assert result.exit_code == 0
+    assert "[DRY RUN, NO FILES AFFECTED]" in result.stdout
+    assert "Moved to trash: 123" in result.stdout
+    mock_get_service.assert_not_called()
+
+@patch("pygog.commands.drive.get_service")
+def test_delete_dry_run_json(mock_get_service):
+    state.json_output = True
+    result = runner.invoke(app, ["delete", "123", "--dry-run"])
+    assert result.exit_code == 0
+    assert '"dryRun": true' in result.stdout
+    assert '"action": "deleted"' in result.stdout
+    assert '"fileId": "123"' in result.stdout
+    mock_get_service.assert_not_called()


### PR DESCRIPTION
Fixes #6

Introduce a `--dry-run` flag for destructive Drive commands, allowing users to preview actions without executing any API calls.

**Scope**
The `--dry-run` flag applies to:
- `drive delete` (trash)
- `drive move`
- `drive rename`

**Expected Behavior**
When `--dry-run` is enabled:
- Display the file ID along with the intended target path or new name
- **Do not** make any calls to the Drive API (except for read-only metadata lookups)
- Ensure output format remains consistent with existing flags:
  - `--json` format updated to specify it is a dry run.
  - `--plain` format updated to strip rich text and specify it is a dry run.

---
*PR created automatically by Jules for task [11857363464550756116](https://jules.google.com/task/11857363464550756116) started by @DhruvGarg111*
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/dhruvgarg111/py-goog-cli/pull/13" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
